### PR TITLE
Change payload logging to show only keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ async function run() {
       return
     }
 
-    // Log the entire payload for debugging
-    console.log('Payload:', JSON.stringify(payload, null, 2));
+    // Log all payload keys for debugging
+    core.debug(`Payload keys: ${Object.keys(payload).join(', ')}`);
     
     const state = payload.state
     core.debug(`context:    ${payload.context}`)


### PR DESCRIPTION
Updated logging to display payload keys instead of the entire payload for improved debugging.